### PR TITLE
fix: add flat attribute to avoid double selector on events

### DIFF
--- a/sn/src/paper_token.cairo
+++ b/sn/src/paper_token.cairo
@@ -54,12 +54,19 @@ mod paper_token {
     #[event]
     #[derive(Copy, Drop, starknet::Event)]
     enum Event {
+        #[flat]
         InitializableEvent: initializable_component::Event,
+        #[flat]
         ERC20MetadataEvent: erc20_metadata_component::Event,
+        #[flat]
         ERC20BalanceEvent: erc20_balance_component::Event,
+        #[flat]
         ERC20AllowanceEvent: erc20_allowance_component::Event,
+        #[flat]
         ERC20MintableEvent: erc20_mintable_component::Event,
+        #[flat]
         ERC20BurnableEvent: erc20_burnable_component::Event,
+        #[flat]
         ERC20BridgeableEvent: erc20_bridgeable_component::Event,
     }
 


### PR DESCRIPTION
We should use `#[flat]` on contract event to ensure correct indexing of standard ERC20 events.

Maybe `InitializeEvent` may not be flat though.